### PR TITLE
Fix page load

### DIFF
--- a/components/sections/ImpactBanner/ImpactBanner.tsx
+++ b/components/sections/ImpactBanner/ImpactBanner.tsx
@@ -19,8 +19,8 @@ export const ImpactBanner: FC<Props> = (props) => {
     >
       <span className={styles.title}>{section_title[0].text}</span>
       <div>
-        {icon_list_elements.map((item) => (
-          <ImpactItem data={item} />
+        {icon_list_elements.map((item, index) => (
+          <ImpactItem data={item} key={index} />
         ))}
       </div>
     </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10798,9 +10798,9 @@
       },
       "dependencies": {
         "jsonparse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-          "integrity": "sha1-JiL05mwI4arH7b63YFPJt+EhH3Y=",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
         }
       }

--- a/pages/[...site].tsx
+++ b/pages/[...site].tsx
@@ -59,9 +59,11 @@ class Site extends Component<Props> {
           />
         </Head>
         <main>
-          {props.allLandings.edges[0].node.sections.map(({ section }) => {
+          {props.allLandings.edges[0].node.sections
+            .filter(({ section }) => section.__typename in sections)
+            .map(({ section }, index) => {
             const Container = sections[section.__typename];
-            return <Container data={section} />;
+            return <Container data={section} key={index} />;
           })}
         </main>
       </div>


### PR DESCRIPTION
This PR fixes:
- The un-updated `package-lock.json` file.
- The page crashing when there's a section that doesn't  have a coded component loaded in Prismic.
- Some key props that were missing.