### PR TITLE
Fix firebase.json so it does not ignore fonts

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -20,7 +20,9 @@
       }
     ],
     "ignore": [
-      "!dist/_next/static/**"
+      "dist/_next/cache/**",
+      "dist/_next/server/**",
+      "dist/_next/cache/**"
     ]
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -21,8 +21,7 @@
     ],
     "ignore": [
       "dist/_next/cache/**",
-      "dist/_next/server/**",
-      "dist/_next/cache/**"
+      "dist/_next/server/**"
     ]
   }
 }


### PR DESCRIPTION
firebase.json file attempts to provide a whitelist semantic in its "ignores" property for firebase hosting, so the only assets that are uploaded are the ones in dist/_next/static. This prevents, however, fonts from being uploaded (since they reside in dist/fonts after upload). The "ignores" list, unfortunately, treats every entry as an exclusion set, and uses the joint set of all these to obtain the complete set of ignored files. This does not allow overriding of ignore rules with ones with more specificity, so there is no way of stating "ignore everything in this folder, except this". Turning the list into a blacklist, and stating the folders and files that need to be ignored, instead of specifying the ones which do not, fixes this problem.

<img width="1440" alt="Screen Shot 2020-08-03 at 12 03 51" src="https://user-images.githubusercontent.com/3202866/89197059-88bff380-d581-11ea-9b00-a90178548b09.png">

Fixes #40.