### PR TITLE
Fix sizes and fonts

### DIFF
--- a/components/sections/Tabs/TabsDesktop/TabsDesktop.scss
+++ b/components/sections/Tabs/TabsDesktop/TabsDesktop.scss
@@ -4,20 +4,16 @@
   min-height: 300px;
   padding-top: 50px;
   padding-bottom: 50px;
-  font-family: $poppins-semibold;
   background-color: #31683d;
 }
 
 .tabs-name {
+  font-family: $poppins-semibold;
   display: flex;
   flex-direction: row;
   padding-bottom: 30px;
   justify-content: center;
   align-content: center;
-}
-
-.tab-title {
-  color: #ffffff;
 }
 
 .tab-name {
@@ -31,6 +27,13 @@
 
 .tabs-content {
   padding: 0 15vw;
+  text-align: center;
+}
+
+.tabs-content p {
+  font-family: $poppins-semibold;
+  font-size: 18px;
+  color: #ffffff;
 }
 
 .selected-tab-name {

--- a/components/sections/Tabs/TabsDesktop/TabsDesktop.tsx
+++ b/components/sections/Tabs/TabsDesktop/TabsDesktop.tsx
@@ -19,15 +19,6 @@ export class TabsDesktop extends PureComponent<Props, { selectedTab: number }> {
     this.setState({ selectedTab: index });
   }
 
-  private tabNameColor(index: number): string {
-    const { tabs_name_selected_color } = this.props;
-    const { selectedTab } = this.state;
-
-    if (selectedTab === index) {
-      return tabs_name_selected_color ?? "#df8832";
-    }
-  }
-
   private isSelectedTab(index: number): boolean {
     const { selectedTab } = this.state;
     return selectedTab === index;
@@ -68,10 +59,9 @@ export class TabsDesktop extends PureComponent<Props, { selectedTab: number }> {
         <div className={styles.tabsContent}>
           {tabs_list.map((tab, index) => (
             <div
-              key={`tab-contant-${index}`}
-              className={styles.tabTitle}
+              key={`tab-content-${index}`}
+              className={styles.tabContent}
               style={{
-                color: tab.content_color,
                 display: this.isSelectedTab(index) ? "block" : "none",
               }}
             >

--- a/components/sections/Tabs/TabsMobile/TabsMobile.scss
+++ b/components/sections/Tabs/TabsMobile/TabsMobile.scss
@@ -2,7 +2,6 @@
 
 .tabs {
   min-height: 300px;
-  font-family: $poppins-semibold;
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
@@ -16,14 +15,19 @@
     flex-direction: column;
 
     .name {
+      font-family: $poppins-semibold;
       font-size: 20px;
       color: #df8832;
     }
 
     .content {
       text-align: center;
-      font-size: 15px;
       color: #000000;
+    }
+
+    .content p {
+      font-family: $poppins-semibold;
+      font-size: 15px;
     }
   }
 }


### PR DESCRIPTION
Provides fixes to the Tabs component.
The size, the font-type and the text centering of the content was wrong.

<img width="1046" alt="Screen Shot 2020-08-11 at 15 59 01" src="https://user-images.githubusercontent.com/1120791/89937739-e4c2f180-dbeb-11ea-9059-d3312010a185.png">
<img width="375" alt="Screen Shot 2020-08-11 at 15 57 59" src="https://user-images.githubusercontent.com/1120791/89937744-e5f41e80-dbeb-11ea-993f-022fe0185bf9.png">
