### PR TITLE
Fix named function warning

### DIFF
--- a/lib/withData.js
+++ b/lib/withData.js
@@ -2,7 +2,7 @@ import React from "react";
 import initEnvironment from "./createRelayEnvironment";
 import { fetchQuery, ReactRelayContext } from "react-relay";
 
-export default (ComposedComponent, options = {}) => {
+export default function withData(ComposedComponent, options = {}) {
   return class WithData extends React.Component {
     static displayName = `WithData(${ComposedComponent.displayName})`;
 
@@ -53,4 +53,4 @@ export default (ComposedComponent, options = {}) => {
       );
     }
   };
-};
+}


### PR DESCRIPTION
The following warn appears when running `npm run dev`:

![image](https://user-images.githubusercontent.com/6027291/94808878-2c822000-03c8-11eb-8989-71b3b764fd84.png)
