### PR TITLE
Fix icon tabs style

### DIFF
--- a/components/sections/IconTabs/Content/Content.scss
+++ b/components/sections/IconTabs/Content/Content.scss
@@ -1,0 +1,15 @@
+@import "styles/colors";
+@import "styles/fonts";
+
+.read-more-button {
+  color: white;
+  width: 150px;
+  background-color: $gold-drop;
+  padding: 8px;
+  border-radius: 4px;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-size: 15px;
+  font-family: $poppins-semibold;
+  text-align: center;
+}

--- a/components/sections/IconTabs/Content/Content.tsx
+++ b/components/sections/IconTabs/Content/Content.tsx
@@ -1,0 +1,25 @@
+// React/Relay
+import React from "react";
+import styles from "./Content.scss";
+import Text from "../../../text";
+
+export const Content = ({
+  className,
+  content,
+  link,
+}: {
+  className?: string;
+  content: any;
+  link?: string;
+}) => {
+  return (
+    <div className={className}>
+      <Text elements={content} />
+      {link && (
+        <a className={styles.readMoreButton} href={link} target="_blank">
+          Leer mas
+        </a>
+      )}
+    </div>
+  );
+};

--- a/components/sections/IconTabs/Content/index.ts
+++ b/components/sections/IconTabs/Content/index.ts
@@ -1,0 +1,1 @@
+export * from "./Content";

--- a/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.scss
+++ b/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.scss
@@ -70,7 +70,6 @@
 }
 
 .tab-content {
-  // display: none !important;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.scss
+++ b/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.scss
@@ -5,7 +5,7 @@
 .container {
   background-size: cover;
   background-position: center;
-  
+
   h1 {
     margin: 0 auto 50px;
     width: 680px;
@@ -51,7 +51,7 @@
 .tab-title {
   text-transform: uppercase;
   font-family: $poppins-semibold;
-  font-size: 20px;
+  font-size: 24px;
   letter-spacing: 2px;
 
   .selected & {
@@ -70,16 +70,26 @@
 }
 
 .tab-content {
+  // display: none !important;
   display: flex;
   flex-direction: column;
   align-items: center;
   flex: 1;
   justify-content: space-between;
   padding: 0 50px;
-}
 
-.tab-content img {
-  max-width: 400px;
+  img {
+    max-width: 400px;
+  }
+
+  h6 {
+    font-size: 15px;
+    font-family: $poppins-regular;
+    color: gray;
+    text-align: center;
+    max-width: 400px;
+    margin: 0;
+  }
 }
 
 .tab-icon {
@@ -87,31 +97,9 @@
   margin-right: 20px;
 }
 
-.tab-content h6 {
-  font-size: 12px;
-  font-family: $poppins-regular;
-  color: gray;
-  text-align: center;
-  max-width: 400px;
-  margin: 0;
-}
-
 .tab-info {
   display: flex;
   align-items: center;
-}
-
-.read-more-button {
-  color: white;
-  width: 150px;
-  background-color: $gold-drop;
-  padding: 8px;
-  border-radius: 4px;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  font-family: $poppins-semibold;
-  text-align: center;
 }
 
 .mobile-content {
@@ -130,10 +118,6 @@
 
   .mobile-content {
     display: inherit;
-  }
-
-  .web-content {
-    display: none !important;
   }
 
   .tabs {

--- a/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.tsx
+++ b/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.tsx
@@ -5,28 +5,8 @@ import classnames from "classnames";
 // Component
 import { Props } from "../IconTabs.types";
 import styles from "./IconTabsDesktop.scss";
-import Text from "../../../text";
+import { Content } from "../Content";
 
-const Content = ({
-  className,
-  content,
-  link,
-}: {
-  className?: string;
-  content: any;
-  link?: string;
-}) => {
-  return (
-    <div className={classnames(styles.tabContent, className)}>
-      <Text elements={content} />
-      {link && (
-        <a className={styles.readMoreButton} href={link} target="_blank">
-          Leer mas
-        </a>
-      )}
-    </div>
-  );
-};
 export const IconTabsDesktop: FC<Props> = (props) => {
   const [selectedTab, setSelectedTab] = useState(0);
   const {
@@ -48,7 +28,7 @@ export const IconTabsDesktop: FC<Props> = (props) => {
         {!title_enlarged ? (
           <span className="vertical-title">{section_title[0].text}</span>
         ) : null}
-        <div className={classnames(styles.tabs, styles.webContent)}>
+        <div className={styles.tabs}>
           {icon_tabs.map((tab, index) => (
             <button
               key={index}
@@ -69,19 +49,8 @@ export const IconTabsDesktop: FC<Props> = (props) => {
             </button>
           ))}
         </div>
-        <div className={classnames(styles.tabs, styles.mobileContent)}>
-          {icon_tabs.map((tab, index) => (
-            <div key={index} className={styles.tabContainer}>
-              <span className={styles.tabTitle}>{tab.tab_title[0].text}</span>
-              <Content
-                content={tab.tab_content}
-                link={tab.tab_link && tab.tab_link.url}
-              />
-            </div>
-          ))}
-        </div>
         <Content
-          className={styles.webContent}
+          className={styles.tabContent}
           content={icon_tabs[selectedTab].tab_content}
           link={
             icon_tabs[selectedTab].tab_link &&

--- a/components/sections/IconTabs/IconTabsMobile/IconTabsMobile.scss
+++ b/components/sections/IconTabs/IconTabsMobile/IconTabsMobile.scss
@@ -96,6 +96,14 @@
   .tab:not(.selected) & {
     display: none;
   }
+
+  h6 {
+    font-size: 13px;
+    padding: 10px 0 10px 0;
+    font-family: $poppins-regular;
+    color: gray;
+    text-align: center;
+  }
 }
 
 .tabSelectedIcon {
@@ -107,27 +115,6 @@
 .tab-icon {
   max-width: 60px;
   margin-right: 20px;
-}
-
-.tab-content h6 {
-  font-size: 13px;
-  padding: 10px 0 10px 0;
-  font-family: $poppins-regular;
-  color: gray;
-  text-align: center;
-}
-
-.read-more-button {
-  color: white;
-  width: 150px;
-  background-color: $gold-drop;
-  padding: 8px;
-  border-radius: 4px;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: 12px;
-  font-family: $poppins-semibold;
-  text-align: center;
 }
 
 .mobile-content {

--- a/components/sections/IconTabs/IconTabsMobile/IconTabsMobile.tsx
+++ b/components/sections/IconTabs/IconTabsMobile/IconTabsMobile.tsx
@@ -1,32 +1,12 @@
 // React/Relay
 import React, { FC, useState } from "react";
 import classnames from "classnames";
+import { Content } from "../Content";
 
 // Component
 import { Props } from "../IconTabs.types";
 import styles from "./IconTabsMobile.scss";
-import Text from "../../../text";
 
-const Content = ({
-  className,
-  content,
-  link,
-}: {
-  className?: string;
-  content: {};
-  link?: string;
-}) => {
-  return (
-    <div className={classnames(styles.tabContent, className)}>
-      <Text elements={content} />
-      {link && (
-        <a className={styles.readMoreButton} href={link} target="_blank">
-          Leer mas
-        </a>
-      )}
-    </div>
-  );
-};
 export const IconTabsMobile: FC<Props> = (props) => {
   const [selectedTab, setSelectedTab] = useState(null);
   const {
@@ -79,6 +59,7 @@ export const IconTabsMobile: FC<Props> = (props) => {
               </div>
               <div key={index} className={styles.tabContent}>
                 <Content
+                  className={styles.tabContent}
                   content={tab.tab_content}
                   link={tab.tab_link && tab.tab_link.url}
                 />

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -124,7 +124,7 @@ a > strong {
     writing-mode: vertical-rl;
     align-self: flex-start;
     margin-right: 30px;
-    font-size: 12px;
+    font-size: 16px;
 
     @media (max-width: $mobile-max) {
       transform: none;


### PR DESCRIPTION
Changes:
- The Content component in the IconTabs section is refactored to be used in the mobile and desktop version.
- The desktop version in the IconTabs component gets stripped of the mobile content.
- Increased the font size of the content of the tabs, the tabs items and the button.

Fixes:
<img width="1317" alt="Screen Shot 2020-10-24 at 23 19 41" src="https://user-images.githubusercontent.com/1120791/97097496-d9f6f500-164f-11eb-85f9-3ce0ad6cc3a9.png">
Old:
<img width="1159" alt="Screen Shot 2020-10-24 at 23 20 25" src="https://user-images.githubusercontent.com/1120791/97097498-debba900-164f-11eb-8159-d6d7cd71d97f.png">
New:
<img width="1163" alt="Screen Shot 2020-10-24 at 23 19 57" src="https://user-images.githubusercontent.com/1120791/97097499-dfecd600-164f-11eb-8148-eb33cfba8282.png">
