### PR TITLE
Fit top banner to viewport height

### DIFF
--- a/components/sections/home-banner/HomeBanner.scss
+++ b/components/sections/home-banner/HomeBanner.scss
@@ -3,6 +3,8 @@
   background-size: cover;
   background-position: left;
   height: 800px;
+  min-height: 600px;
+  max-height: 100vh;
   display: flex;
 }
 


### PR DESCRIPTION
Fit top banner to viewport height so that the "I want to help button" is always visible. If viewport is high enough so that the button is visible, height is not changed. If viewport is small enough so that the text will collide with header, do not adjust it beyond header.

Before:
![image](https://user-images.githubusercontent.com/6027291/99183901-1cc35e80-271e-11eb-96c3-bb58dd025a81.png)

After:
![image](https://user-images.githubusercontent.com/6027291/99183906-26e55d00-271e-11eb-850b-5e756c701647.png)

Before:
![image](https://user-images.githubusercontent.com/6027291/99183847-bb02f480-271d-11eb-9fc5-908a5c7bfc70.png)

After:
![image](https://user-images.githubusercontent.com/6027291/99183841-a7578e00-271d-11eb-8f6e-9134f6d011f9.png)

Big screen:
![image](https://user-images.githubusercontent.com/6027291/99183923-5005ed80-271e-11eb-8d7d-be87c82ee6d0.png)

Small screen (horizontal phone):
![image](https://user-images.githubusercontent.com/6027291/99183960-77f55100-271e-11eb-9445-0fbf08061dfa.png)
