### PR TITLE
Fit icon tabs height to tallest content

### DIFF
--- a/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.scss
+++ b/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.scss
@@ -19,8 +19,18 @@
 }
 
 .illustration {
-  -webkit-mask-image:-webkit-gradient(linear, left bottom, left top, color-stop(70%, rgba(0,0,0,1)), color-stop(100%, rgba(0,0,0,0)));
-  mask-image: linear-gradient(to top, rgba(0,0,0,1) 70%, rgba(0,0,0,0) 100%);
+  -webkit-mask-image: -webkit-gradient(
+    linear,
+    left bottom,
+    left top,
+    color-stop(70%, rgba(0, 0, 0, 1)),
+    color-stop(100%, rgba(0, 0, 0, 0))
+  );
+  mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 1) 70%,
+    rgba(0, 0, 0, 0) 100%
+  );
   display: block;
   width: calc(100% + #{$section-horizontal-padding * 2});
   margin-left: -$section-horizontal-padding;
@@ -69,13 +79,22 @@
   }
 }
 
-.tab-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+.tabs-content {
   flex: 1;
-  justify-content: space-between;
   padding: 0 50px;
+  display: flex;
+  overflow-x: hidden;
+}
+
+.tab-content {
+  flex-shrink: 0;
+  width: 100%;
+  visibility: hidden;
+
+  &.selected {
+    order: -1;
+    visibility: visible;
+  }
 
   img {
     max-width: 400px;

--- a/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.tsx
+++ b/components/sections/IconTabs/IconTabsDesktop/IconTabsDesktop.tsx
@@ -49,11 +49,18 @@ export const IconTabsDesktop: FC<Props> = (props) => {
             </button>
           ))}
         </div>
-        <Content
-          className={styles.tabContent}
-          content={icon_tabs[selectedTab].tab_content}
-          link={icon_tabs[selectedTab].tab_link}
-        />
+        <div className={styles.tabsContent}>
+          {icon_tabs.map((tab, index) => (
+            <Content
+              key={index}
+              className={classnames(styles.tabContent, {
+                [styles.selected]: index === selectedTab,
+              })}
+              content={tab.tab_content}
+              link={tab.tab_link}
+            />
+          ))}
+        </div>
       </div>
       {background_illustration && (
         <img

--- a/components/sections/Tabs/TabsDesktop/TabsDesktop.scss
+++ b/components/sections/Tabs/TabsDesktop/TabsDesktop.scss
@@ -25,6 +25,11 @@
   padding-bottom: 5px;
 }
 
+.selected-tab-name {
+  border-bottom: 3px solid #df8832;
+  color: #df8832;
+}
+
 .tabs-content {
   padding: 0 15vw;
   text-align: center;
@@ -34,13 +39,16 @@
   justify-content: center;
 }
 
-.tabs-content p {
+.tab-content {
+  display: none;
+}
+
+.selected-tab-content {
+  display: block;
+}
+
+.tab-content p {
   font-family: $poppins-semibold;
   font-size: 18px;
   color: #ffffff;
-}
-
-.selected-tab-name {
-  border-bottom: 3px solid #df8832;
-  color: #df8832;
 }

--- a/components/sections/Tabs/TabsDesktop/TabsDesktop.tsx
+++ b/components/sections/Tabs/TabsDesktop/TabsDesktop.tsx
@@ -60,10 +60,9 @@ export class TabsDesktop extends PureComponent<Props, { selectedTab: number }> {
           {tabs_list.map((tab, index) => (
             <div
               key={`tab-content-${index}`}
-              className={styles.tabContent}
-              style={{
-                display: this.isSelectedTab(index) ? "block" : "none",
-              }}
+              className={classnames(styles.tabContent, {
+                [styles.selectedTabContent]: this.isSelectedTab(index),
+              })}
             >
               <Text elements={tab.content} />
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2702,6 +2702,12 @@
         "@types/node": "*"
       }
     },
+    "@types/classnames": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
+      "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-responsive": "^8.1.0"
   },
   "devDependencies": {
+    "@types/classnames": "^2.2.11",
     "@types/node": "^13.11.1",
     "@types/react": "^16.9.35",
     "babel-plugin-relay": "^9.1.0",


### PR DESCRIPTION
To avoid changing page height when selecting sections, render all contents but hide the ones that are not selected. Use `order: -1` so that the visible element is always shown first. The other elements will be to the right of this one, but they don't take horizontal scroll because of the `overflow-x: hidden`.

![Nov-15-2020 09-46-54](https://user-images.githubusercontent.com/6027291/99185359-08845f00-2728-11eb-81ed-1665a4c6d447.gif)
