### PR TITLE
Minor tweaks

### DIFF
--- a/components/sections/Card/Card.scss
+++ b/components/sections/Card/Card.scss
@@ -12,26 +12,24 @@
 }
 
 .card-image {
-  @media(max-width: 768px) {
+  @media (max-width: 768px) {
     text-align: center;
     padding-right: 0;
   }
 
   &.avatar {
     img {
-
       border: 2px solid #643633;
       width: 200px;
       height: 200px;
     }
   }
-  
+
   img {
     border-radius: 50%;
-    
     width: 150px;
     height: 150px;
-    
+
     @media (max-width: 768px) {
       width: 180px;
       height: 180px;
@@ -50,11 +48,11 @@
   justify-content: center;
   display: flex;
   min-height: 400px;
-  
+
   &.white {
     background-color: white;
   }
-  
+
   &.opaque {
     background-color: $mercury;
   }
@@ -65,7 +63,7 @@
   white-space: nowrap;
   display: flex;
   justify-content: left;
-  
+
   @media (max-width: 768px) {
     align-self: flex-start;
   }

--- a/components/sections/GridSection/GridSection.scss
+++ b/components/sections/GridSection/GridSection.scss
@@ -14,6 +14,10 @@
 
 .title {
   color: $jewel;
+
+  @media (max-width: $mobile-max) {
+    font-size: 24px;
+  }
 }
 
 .subtitle {
@@ -26,7 +30,6 @@
   grid-template-columns: 1fr 1fr 1fr 1fr;
   gap: 60px;
   margin-top: 60px;
-
 
   @media (max-width: $mobile-max) {
     grid-template-columns: 1fr 1fr;

--- a/components/sections/IconTabs/IconTabsMobile/IconTabsMobile.scss
+++ b/components/sections/IconTabs/IconTabsMobile/IconTabsMobile.scss
@@ -71,7 +71,7 @@
   span {
     text-transform: uppercase;
     font-family: $poppins-semibold;
-    font-size: 17px;
+    font-size: 20px;
     letter-spacing: 2px;
     line-height: normal;
   }

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -100,14 +100,14 @@ a > strong {
   }
 
   p {
-    font-size: 12px;
+    font-size: 15px;
   }
 
   a > strong,
   strong > a {
     margin: 0 auto;
     display: block;
-    width: 120px;
+    max-width: 160px;
   }
 }
 


### PR DESCRIPTION
Increases the font size of the paragraphs in mobile so it is clearer. Reading the text in mobile was kind of hard.
After:
<img width="414" alt="Screen Shot 2020-11-16 at 20 41 32" src="https://user-images.githubusercontent.com/1120791/99322424-affbb180-284e-11eb-81c3-bd2d989b9266.png">
<img width="416" alt="Screen Shot 2020-11-16 at 20 52 59" src="https://user-images.githubusercontent.com/1120791/99322430-b2f6a200-284e-11eb-9194-e479ac8a4bec.png">
Before:
<img width="415" alt="Screen Shot 2020-11-16 at 20 55 56" src="https://user-images.githubusercontent.com/1120791/99322434-b38f3880-284e-11eb-851b-4633d1f29786.png">
<img width="409" alt="Screen Shot 2020-11-16 at 20 56 14" src="https://user-images.githubusercontent.com/1120791/99322437-b4c06580-284e-11eb-853f-2c3d01b7b62b.png">

Reduces the title size in mobile so it's not too big:
After:
<img width="421" alt="Screen Shot 2020-11-16 at 20 29 36" src="https://user-images.githubusercontent.com/1120791/99322445-b7bb5600-284e-11eb-89db-f95016b429ec.png">
Before;
![Screen Shot 2020-11-16 at 12 15 01](https://user-images.githubusercontent.com/1120791/99322544-e6393100-284e-11eb-9a71-fb48233aaa8c.png)

Augments the size of the href buttons:
After:
<img width="423" alt="Screen Shot 2020-11-16 at 21 03 58" src="https://user-images.githubusercontent.com/1120791/99322752-63fd3c80-284f-11eb-88e9-7c69a2895c60.png">
Before:
<img width="424" alt="Screen Shot 2020-11-16 at 21 04 14" src="https://user-images.githubusercontent.com/1120791/99322778-76777600-284f-11eb-88b7-80f0f5ae759d.png">

