### PR TITLE
Strip query params from path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16133,9 +16133,9 @@
       }
     },
     "react-intersection-observer": {
-      "version": "8.30.3",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.30.3.tgz",
-      "integrity": "sha512-hKYTJUrU99hAf7h1lNY3pjYXt+09BaPNC6fcLw1B8OLJJUDXTWrwzu4hRuztougeRgPYpxmNaTn1FS4F3EQnhA=="
+      "version": "8.31.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.31.0.tgz",
+      "integrity": "sha512-XraIC/tkrD9JtrmVA7ypEN1QIpKc52mXBH1u/bz/aicRLo8QQEJQAMUTb8mz4B6dqpPwyzgjrr7Ljv/2ACDtqw=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prismic-reactjs": "^1.3.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-intersection-observer": "^8.30.3",
+    "react-intersection-observer": "^8.31.0",
     "react-markdown": "^5.0.2",
     "react-relay": "^9.1.0",
     "react-responsive": "^8.1.1"

--- a/pages/[...site].tsx
+++ b/pages/[...site].tsx
@@ -153,7 +153,11 @@ class Site extends Component<Props> {
   }
 }
 
+function stripQueryParametersFromPath(path: String) {
+  return path.split(/[?#]/)[0];
+}
+
 export default withData(Site, {
   query: Site.query,
-  setupVars: (ctx) => ({ where: { route: ctx.asPath } }),
-});
+  setupVars: (ctx) => ({ where: { route: stripQueryParametersFromPath(ctx.asPath) } })
+  });

--- a/pages/[...site].tsx
+++ b/pages/[...site].tsx
@@ -160,4 +160,4 @@ function stripQueryParametersFromPath(path: String) {
 export default withData(Site, {
   query: Site.query,
   setupVars: (ctx) => ({ where: { route: stripQueryParametersFromPath(ctx.asPath) } })
-  });
+});


### PR DESCRIPTION
This PR splits the query params from the path, allowing the site to support them without throwing a 404.